### PR TITLE
feat(data-table): Implement Global Filtering for the tables

### DIFF
--- a/components/data-table/data-table.tsx
+++ b/components/data-table/data-table.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import {
   ColumnDef,
-  ColumnFiltersState,
   SortingState,
   flexRender,
   getCoreRowModel,
@@ -22,6 +21,7 @@ import {
 } from '@/components/ui/table';
 import { DataTablePagination } from '@/components/data-table/pagination';
 import { DataTableToolbar } from '@/components/data-table/toolbar';
+import { rankItem } from '@tanstack/match-sorter-utils';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -33,20 +33,27 @@ export function DataTable<TData, TValue>({
   data,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [globalFilter, setGlobalFilter] = useState<any>([]);
 
   const table = useReactTable({
-    data,
     columns,
+    data,
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
-    onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: (row, _id, value) => {
+      const columns = row.getAllCells();
+      return columns.some((cell) => {
+        const itemRank = rankItem(cell.getValue(), value);
+        return itemRank.passed;
+      });
+    },
     state: {
       sorting,
-      columnFilters,
+      globalFilter,
     },
   });
 

--- a/components/data-table/toolbar.tsx
+++ b/components/data-table/toolbar.tsx
@@ -22,54 +22,36 @@ export function DataTableToolbar<TData>({
 
   const currentPage = usePathname().split('/')[2];
 
-  let columnToFilter: string | undefined;
-  let placeholder;
+  function handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setFilter(String(event.target.value));
+    table.setGlobalFilter(String(event.target.value));
+  }
 
-  switch (currentPage) {
-    case 'donors': {
-      columnToFilter = 'name';
-      placeholder = 'name';
-      break;
-    }
-    case 'donations': {
-      columnToFilter = 'donorName';
-      placeholder = 'donor name';
-      break;
-    }
-    case 'reports': {
-      break;
-    }
+  function handleResetFilter() {
+    setFilter('');
+    table.resetGlobalFilter();
   }
 
   return (
     <div className="flex items-center justify-between">
-      {columnToFilter && (
-        <div className="flex flex-1 items-center space-x-2">
-          <Input
-            placeholder={`Filter ${placeholder}`}
-            value={
-              (table.getColumn(columnToFilter)?.getFilterValue() as string) ??
-              ''
-            }
-            onChange={(event) =>
-              table
-                .getColumn(columnToFilter)
-                ?.setFilterValue(event.target.value)
-            }
-            className="h-8 w-[150px] lg:w-[250px]"
-          />
-          {isFiltered && (
-            <Button
-              variant="ghost"
-              onClick={() => table.resetColumnFilters()}
-              className="h-8 px-2 lg:px-3"
-            >
-              Reset
-              <X />
-            </Button>
-          )}
-        </div>
-      )}
+      <div className="flex flex-1 items-center space-x-2">
+        <Input
+          placeholder="Filter table..."
+          value={filter}
+          onChange={handleInputChange}
+          className="h-8 w-[150px] lg:w-[250px]"
+        />
+        {isFiltered && (
+          <Button
+            variant="ghost"
+            onClick={handleResetFilter}
+            className="h-8 px-2 lg:px-3"
+          >
+            Reset
+            <X />
+          </Button>
+        )}
+      </div>
       <div className="flex items-center space-x-2">
         {currentPage !== 'donations' && <DataTableViewOptions table={table} />}
         {currentPage === 'donors' && <AddDonorDialog />}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-tooltip": "^1.1.8",
     "@stackframe/stack": "^2.7.30",
     "@tabler/icons-react": "^3.31.0",
+    "@tanstack/match-sorter-utils": "^8.19.4",
     "@tanstack/react-table": "^8.21.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@tabler/icons-react':
         specifier: ^3.31.0
         version: 3.31.0(react@19.0.0)
+      '@tanstack/match-sorter-utils':
+        specifier: ^8.19.4
+        version: 8.19.4
       '@tanstack/react-table':
         specifier: ^8.21.2
         version: 8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2031,6 +2034,10 @@ packages:
   '@tailwindcss/postcss@4.0.15':
     resolution: {integrity: sha512-qyrpoDKIO7wzkRbKCvGLo7gXRjT9/Njf7ZJiJhG4njrfZkvOhjwnaHpYbpxYeDysEg+9pB1R4jcd+vQ7ZUDsmQ==}
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
+    engines: {node: '>=12'}
+
   '@tanstack/react-table@8.21.2':
     resolution: {integrity: sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg==}
     engines: {node: '>=12'}
@@ -3954,6 +3961,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  remove-accents@0.5.0:
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -6159,6 +6169,10 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 4.0.15
 
+  '@tanstack/match-sorter-utils@8.19.4':
+    dependencies:
+      remove-accents: 0.5.0
+
   '@tanstack/react-table@8.21.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@tanstack/table-core': 8.21.2
@@ -8178,6 +8192,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  remove-accents@0.5.0: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
This pull request introduces global filtering functionality to the data table component. Key changes include:

- Implementation of a global filter input field for searching across all columns.
- Addition of a reset button to clear the applied filter.
- Integration of the `@tanstack/match-sorter-utils` library to enable fuzzy matching.
- Removal of the previous column-specific filtering mechanism.